### PR TITLE
Implement ft_strtrim function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ SRCS = ft_isalpha.c \
        ft_strdup.c \
        ft_substr.c \
        ft_strjoin.c \
+       ft_strtrim.c \
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Libft is a personal recreation of some useful standard C library functions. This
 - `ft_strdup` - Duplicate a string
 - `ft_substr` - Extract a substring from a string
 - `ft_strjoin` - Concatenate two strings
+- `ft_strtrim` - Trim specified characters from beginning and end of string
 
 ### Memory Functions
 - `ft_memset` - Fill memory with a constant byte

--- a/ft_strtrim.c
+++ b/ft_strtrim.c
@@ -1,0 +1,71 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strtrim.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: carloga2 <carloga2@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/13 12:30:00 by carloga2          #+#    #+#             */
+/*   Updated: 2025/05/13 12:30:00 by carloga2         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdlib.h>
+
+/**
+ * @brief Check if a character is in a set
+ *
+ * @param c Character to check
+ * @param set Set of characters to check against
+ * @return int 1 if found, 0 if not found
+ */
+static int	ft_char_in_set(char c, char const *set)
+{
+	size_t	i;
+
+	i = 0;
+	while (set[i])
+	{
+		if (set[i] == c)
+			return (1);
+		i++;
+	}
+	return (0);
+}
+
+/**
+ * @brief Trims characters from beginning and end of a string
+ *
+ * This function removes all characters in 'set' from the beginning and end
+ * of string 's1' until a character not in 'set' is found. The trimmed string
+ * is returned with memory allocated via malloc.
+ *
+ * @param s1 The string to trim
+ * @param set The set of characters to trim from s1
+ * @return char* The trimmed string, or NULL if allocation fails
+ */
+char	*ft_strtrim(char const *s1, char const *set)
+{
+	char	*result;
+	size_t	start;
+	size_t	end;
+	size_t	i;
+
+	if (!s1 || !set)
+		return (NULL);
+	start = 0;
+	while (s1[start] && ft_char_in_set(s1[start], set))
+		start++;
+	end = ft_strlen(s1);
+	while (end > start && ft_char_in_set(s1[end - 1], set))
+		end--;
+	result = (char *)malloc(sizeof(char) * (end - start + 1));
+	if (!result)
+		return (NULL);
+	i = 0;
+	while (start < end)
+		result[i++] = s1[start++];
+	result[i] = '\0';
+	return (result);
+}

--- a/ft_strtrim_test.c
+++ b/ft_strtrim_test.c
@@ -1,0 +1,111 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strtrim_test.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: carloga2 <carloga2@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/13 12:30:00 by carloga2          #+#    #+#             */
+/*   Updated: 2025/05/13 12:30:00 by carloga2         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+void	test_normal_case(void)
+{
+	char	*s1 = "  Hello World  ";
+	char	*set = " ";
+	char	*result;
+	
+	result = ft_strtrim(s1, set);
+	if (strcmp(result, "Hello World") != 0)
+		printf("[FAIL] test_normal_case: expected 'Hello World', got '%s'\n", result);
+	else
+		printf("[PASS] test_normal_case\n");
+	free(result);
+}
+
+void	test_multiple_chars_in_set(void)
+{
+	char	*s1 = "\t\nHello World\t\n";
+	char	*set = "\t\n";
+	char	*result;
+	
+	result = ft_strtrim(s1, set);
+	if (strcmp(result, "Hello World") != 0)
+		printf("[FAIL] test_multiple_chars_in_set: expected 'Hello World', got '%s'\n", result);
+	else
+		printf("[PASS] test_multiple_chars_in_set\n");
+	free(result);
+}
+
+void	test_empty_string(void)
+{
+	char	*s1 = "";
+	char	*set = " \t\n";
+	char	*result;
+	
+	result = ft_strtrim(s1, set);
+	if (strcmp(result, "") != 0)
+		printf("[FAIL] test_empty_string: expected empty string, got '%s'\n", result);
+	else
+		printf("[PASS] test_empty_string\n");
+	free(result);
+}
+
+void	test_only_trim_chars(void)
+{
+	char	*s1 = "   \t\n   ";
+	char	*set = " \t\n";
+	char	*result;
+	
+	result = ft_strtrim(s1, set);
+	if (strcmp(result, "") != 0)
+		printf("[FAIL] test_only_trim_chars: expected empty string, got '%s'\n", result);
+	else
+		printf("[PASS] test_only_trim_chars\n");
+	free(result);
+}
+
+void	test_trim_inner_chars(void)
+{
+	char	*s1 = "  Hello  World  ";
+	char	*set = " ";
+	char	*result;
+	
+	result = ft_strtrim(s1, set);
+	if (strcmp(result, "Hello  World") != 0)
+		printf("[FAIL] test_trim_inner_chars: expected 'Hello  World', got '%s'\n", result);
+	else
+		printf("[PASS] test_trim_inner_chars\n");
+	free(result);
+}
+
+void	test_empty_set(void)
+{
+	char	*s1 = "  Hello World  ";
+	char	*set = "";
+	char	*result;
+	
+	result = ft_strtrim(s1, set);
+	if (strcmp(result, "  Hello World  ") != 0)
+		printf("[FAIL] test_empty_set: expected '  Hello World  ', got '%s'\n", result);
+	else
+		printf("[PASS] test_empty_set\n");
+	free(result);
+}
+
+int	main(void)
+{
+	test_normal_case();
+	test_multiple_chars_in_set();
+	test_empty_string();
+	test_only_trim_chars();
+	test_trim_inner_chars();
+	test_empty_set();
+	return (0);
+}

--- a/libft.h
+++ b/libft.h
@@ -39,5 +39,6 @@ void	*ft_calloc(size_t num, size_t size);
 char	*ft_strdup(const char *s1);
 char	*ft_substr(char const *s, unsigned int start, size_t len);
 char	*ft_strjoin(char const *s1, char const *s2);
+char	*ft_strtrim(char const *s1, char const *set);
 
 #endif


### PR DESCRIPTION
Closes #9

This PR implements the ft_strtrim function that trims specified characters from the beginning and end of a string.